### PR TITLE
Update ec2 asg scaling cooldown to 5 mins

### DIFF
--- a/cf_templates/elasticbeanstalk.yaml
+++ b/cf_templates/elasticbeanstalk.yaml
@@ -386,7 +386,7 @@ Resources:
           Value: !Ref ASGMaxSize
         - Namespace: aws:autoscaling:asg
           OptionName: Cooldown
-          Value: 120
+          Value: 300
         - 
           Namespace: "aws:autoscaling:launchconfiguration"
           OptionName: EC2KeyName


### PR DESCRIPTION
Update elasticbeanstalk CF template to set EC2 autoscaling cool down period to 5 minutes.